### PR TITLE
simple search page and algorithm

### DIFF
--- a/lib/pages/main/mainpage_page_header.dart
+++ b/lib/pages/main/mainpage_page_header.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dojo/pages/main/aboutme.dart';
 
+import '../../search/search_mainpage_container.dart';
+
 class MainPagePageHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -13,12 +15,23 @@ class MainPagePageHeader extends StatelessWidget {
             children: <Widget>[
               Container(
                 margin: EdgeInsets.only(left: 16),
-                child: FlutterLogo(),
+                child: GestureDetector(
+                  child: FlutterLogo(),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => SearchMainPage(),
+                      ),
+                    );
+                  },
+                ),
               ),
               Spacer(),
               GestureDetector(
                 onTap: () {
-                  Navigator.push(context, MaterialPageRoute(builder: (context) => AboutMeWidget()));
+                  Navigator.push(context,
+                      MaterialPageRoute(builder: (context) => AboutMeWidget()));
                 },
                 child: Container(
                   margin: EdgeInsets.only(right: 16),

--- a/lib/search/search_mainpage_container.dart
+++ b/lib/search/search_mainpage_container.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dojo/search/search_utils.dart';
+
+class SearchMainPage extends StatefulWidget {
+  @override
+  SearchState createState() {
+    return SearchState();
+  }
+}
+
+class SearchState extends State<SearchMainPage> {
+  //测试用数据，后期可以换成map来支持页面跳转
+  List<String> testDictionary = [
+    'Accessibility',
+    'Animation and motion',
+    'Async',
+    'App stucture and navigation',
+    'Assets,images,and icon',
+    'Basic',
+    'Buttons',
+    'Cupertino',
+    'Dialog,alerts,and panels',
+    'Information displays',
+    'Input',
+    'Input and selections',
+    'Layout',
+    'Multu-child layout',
+    'Painting and effet',
+    'Routing',
+    'Scrolling',
+    'Single-child layout widgets',
+    'Styling',
+    'Text',
+    'Touch interactions',
+    'CatchError',
+    'File',
+    'Key',
+    'LifeCycle',
+    'Json',
+    'PageRoute',
+    'Provider',
+    'ProviderState'
+  ];
+  String input = '';//用户在输入框输入的文字
+  Set<String> result;//返回的关键词搜索结果
+  TextEditingController _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    SearchUtils().updateWords(testDictionary);//把字典加入搜索工具中
+    _controller.addListener(() {
+      setState(() {
+        input = _controller?.text;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> textList = new List();
+
+    if (input != null && input.trim() != "") {
+      // defaultSearchStrategy是默认的搜索关键词匹配策略，
+      // 也可以用searchSimilarWords匹配相似单词，用searchWordsInTrie匹配前缀，自己设定参数
+      // 如果把单词倒过来加入字典，还可以用searchWordsInTrie匹配到后缀
+      result = SearchUtils().defaultSearchStrategy(input);
+      result.forEach((item) {
+        textList.add(getItem(item));
+      });
+    }
+    return Scaffold(
+      body: Container(
+        width: MediaQuery.of(context).size.width,
+        height: MediaQuery.of(context).size.height,
+        margin: EdgeInsets.only(top: 30),
+        padding: EdgeInsets.only(left: 10, right: 10, top: 5, bottom: 5),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            getSearchBar(context),
+            Expanded(
+              child: ListView.builder(
+                itemCount: textList.length,
+                itemBuilder: (context, position) {
+                  return textList[position];
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  getSearchBar(context) {
+    return Container(
+      width: MediaQuery.of(context).size.width,
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Container(
+              height: 30,
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: Colors.grey,
+                  width: 1,
+                ),
+                borderRadius: BorderRadius.all(
+                  Radius.circular(5),
+                ),
+              ),
+              child: Row(
+                children: <Widget>[
+                  Icon(
+                    Icons.search,
+                  ),
+                  Expanded(
+                    child: TextField(
+                      decoration: InputDecoration(
+                        border: InputBorder.none,
+                      ),
+                      keyboardType: TextInputType.text,
+                      controller: _controller,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          GestureDetector(
+            child: Container(
+              margin: EdgeInsets.only(left: 5),
+              child: Text(
+                '返回',
+                style: TextStyle(fontSize: 12, color: Colors.black),
+              ),
+            ),
+            onTap: () {
+              Navigator.pop(context);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  getItem(String s) {
+    return Container(
+      padding: EdgeInsets.only(top: 5, bottom: 5),
+      child: Text(
+        s,
+        style: TextStyle(fontSize: 16),
+      ),
+    );
+  }
+}

--- a/lib/search/search_utils.dart
+++ b/lib/search/search_utils.dart
@@ -1,0 +1,172 @@
+import 'dart:math';
+
+class SearchUtils {
+  static TreeNode _dictionaryTree, _copy;
+  static List<String> _dictionaryList;
+  List<String> _prefixSearchResult;
+  List<String> _similaritySearchResult;
+
+  ///默认的搜索策略
+  ///默认的最大编辑距离是字符串长度整除4,起码允许打错1个字符
+  ///结果用Set返回，去除了重复数据
+  Set<String> defaultSearchStrategy(String word) {
+    Set<String> result = new Set();
+
+    int defaultDistance = word.length ~/ 4;
+    if (defaultDistance < 1) {
+      defaultDistance = 1;
+    }
+    result.addAll(searchSimilarWords(word, defaultDistance));
+    result.addAll(searchWordsInTrie(word));
+    return result;
+  }
+
+  ///从字典中搜索和input相似的单词，编辑距离小等于distance
+  List<String> searchSimilarWords(String inputWord, int distance) {
+    if (_similaritySearchResult == null) {
+      _similaritySearchResult = List();
+    }
+    for (String wordInDictionary in _dictionaryList) {
+      if (_matchSimilarWords(wordInDictionary, inputWord, distance)) {
+        _similaritySearchResult.add(wordInDictionary);
+      }
+    }
+    return _similaritySearchResult;
+  }
+
+  bool _matchSimilarWords(String word1, String word2, int distance) {
+    List<List<int>> dp = new List();
+    int len1 = word1.length;
+    int len2 = word2.length;
+    for (int i = 0; i < len1; i++) {
+      dp.add(new List(len2));
+    }
+    dp[0][0] = word1[0].toLowerCase() == word2[0].toLowerCase() ? 0 : 1;
+
+    for (int i = 1; i < len1; i++) {
+      if (word1[i] == word2[0] && dp[i - 1][0] + 1 > i) {
+        dp[i][0] = i;
+      } else {
+        dp[i][0] = dp[i - 1][0] + 1;
+      }
+    }
+    for (int j = 1; j < len2; j++) {
+      if (word2[j] == word1[0] && dp[0][j - 1] + 1 > j) {
+        dp[0][j] = j;
+      } else {
+        dp[0][j] = dp[0][j - 1] + 1;
+      }
+    }
+    for (int i = 1; i < len1; i++) {
+      for (int j = 1; j < len2; j++) {
+        dp[i][j] = min(dp[i - 1][j] + 1, dp[i][j - 1] + 1);
+        int convert = word1[i].toLowerCase() == word2[j].toLowerCase() ? 0 : 1;
+        dp[i][j] = min(dp[i][j], dp[i - 1][j - 1] + convert);
+      }
+    }
+    return dp[len1 - 1][len2 - 1] <= distance;
+  }
+
+  ///通过前缀在字典树中查找所有单词
+  List<String> searchWordsInTrie(String prefix) {
+    if (_dictionaryTree == null) {
+      return new List<String>();
+    }
+    _copy = _dictionaryTree;
+    _prefixSearchResult = new List<String>();
+    String matchedPrefix = "";
+    for (int i = 0; i < prefix.length; i++) {
+      if (!_matchLetter(prefix[i])) {
+        return new List<String>();
+      } else {
+        matchedPrefix = matchedPrefix + _copy.val;
+      }
+    }
+    _searchAllWords(matchedPrefix, _copy);
+    return _prefixSearchResult;
+  }
+
+  bool _matchLetter(String letter) {
+    for (TreeNode child in _copy.children) {
+      if (letter.toLowerCase() == child.val.toLowerCase()) {
+        _copy = child;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void _searchAllWords(String result, TreeNode copy) {
+    if (copy.endFlag) {
+      _prefixSearchResult.add(result);
+    }
+    for (TreeNode child in copy.children) {
+      _searchAllWords(result + child.val, child);
+    }
+  }
+
+  ///更新单词组
+  updateWords(List<String> words) {
+    clearDictionary();
+    for (String word in words) {
+      addWord(word);
+    }
+  }
+
+  ///添加单个的单词
+  addWord(String word) {
+    if (_dictionaryList == null) {
+      _dictionaryList = new List<String>();
+    }
+    _dictionaryList.add(word);
+
+    if (_dictionaryTree == null) {
+      _dictionaryTree = new TreeNode("");
+    }
+    _copy = _dictionaryTree;
+    for (int i = 0; i < word.length; i++) {
+      _addWordInTrie(word[i], i == word.length - 1);
+    }
+  }
+
+  _addWordInTrie(String c, bool endFlag) {
+    bool containFlag = false;
+    for (TreeNode child in _copy.children) {
+      if (child.val.toLowerCase() == c.toLowerCase()) {
+        containFlag = true;
+        _copy = child;
+        break;
+      }
+    }
+    if (!containFlag) {
+      TreeNode childNode = new TreeNode(c);
+      _copy.children.add(childNode);
+      _copy = childNode;
+    }
+    if (_copy.endFlag == null || !_copy.endFlag) {
+      _copy.endFlag = endFlag;
+    }
+  }
+
+  ///清空整个字典
+  void clearDictionary() {
+    _dictionaryList = null;
+    _dictionaryTree = null;
+    _copy = null;
+    _prefixSearchResult = null;
+  }
+
+  ///清除查找结果
+  void clearSearchResult() {
+    _prefixSearchResult = null;
+    _similaritySearchResult = null;
+  }
+}
+
+class TreeNode {
+  List<TreeNode> children = new List();
+  String val;
+  bool endFlag;
+
+  TreeNode(this.val);
+}


### PR DESCRIPTION
添加了一个搜索页面，入口在主页左上角的FlutterLogo
算法封装在了search_utils里，添加完List<String>类型的字典后可支持模糊搜索和前缀搜索，以及两者的组合，其中模糊搜索可以指定容错率。

目前字典数据仅仅自己做了一点用来测试，而且暂时还没有支持点击跳转，后期可以用map把关键词映射到页面来实现。